### PR TITLE
docs: add CONTRIBUTING guide and expand README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to agentfiles
+
+Thanks for your interest in contributing! This guide covers everything you need to get started.
+
+## Prerequisites
+
+- **Rust** -- nightly toolchain (the project uses the 2024 edition, which requires nightly). Install via [rustup](https://rustup.rs/).
+- **Git** -- required at runtime (agentfiles shells out to `git` for remote source support).
+- **just** (optional) -- a command runner for convenience recipes. Install via `cargo install just` or your system package manager.
+
+## Getting Started
+
+```sh
+git clone https://github.com/leodiegues/agentfiles.git
+cd agentfiles
+cargo build
+cargo test
+```
+
+If all tests pass, you're ready to go.
+
+## Development Commands
+
+The project uses standard Cargo commands. A `justfile` is also provided for convenience.
+
+| Task | Cargo | Just |
+|---|---|---|
+| Build | `cargo build` | `just build` |
+| Run | `cargo run -- <args>` | `just run <args>` |
+| Test (all) | `cargo test` | `just test` |
+| Test (single) | `cargo test <name>` | -- |
+| Lint | `cargo clippy -- -D warnings` | `just lint` |
+| Format | `cargo fmt` | `just fmt` |
+| Format check | `cargo fmt -- --check` | -- |
+| Type-check only | `cargo check` | `just check` |
+| Full CI suite | See below | `just ci` |
+| Clean | `cargo clean` | `just clean` |
+
+### Running CI Locally
+
+Before submitting a PR, run the full CI suite to catch issues early:
+
+```sh
+just ci
+```
+
+Or manually:
+
+```sh
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
+cargo build
+```
+
+All four checks must pass. CI runs these across Linux, macOS, and Windows.
+
+## Project Structure
+
+```
+src/
+  lib.rs         -- pub mod re-exports only
+  types.rs       -- Core enums (FileScope, FileKind, FileStrategy, AgentProvider)
+  provider.rs    -- Provider directory layout resolution, compatibility matrix
+  manifest.rs    -- Manifest/FileMapping structs, JSON load/save
+  scanner.rs     -- Auto-discovery of agent files from directory structures
+  installer.rs   -- File installation (copy/symlink) to provider directories
+  git.rs         -- Remote git URL detection, parsing, clone/cache
+  cli.rs         -- CLI argument parsing (clap derive)
+  commands.rs    -- Command handlers (cmd_install, cmd_init, etc.)
+  main.rs        -- Binary entry point
+```
+
+Dependency flow: `types` <- `provider`, `manifest` <- `scanner`, `installer`. `git` and `cli` are standalone. `main` and `commands` wire everything together.
+
+For a comprehensive reference on module internals, naming conventions, and design principles, see [AGENTS.md](AGENTS.md).
+
+## Code Style
+
+### Formatting
+
+Use default `rustfmt` settings. Run `cargo fmt` before committing.
+
+### Import ordering
+
+Three groups, separated by blank lines:
+
+```rust
+// 1. Standard library
+use std::fs;
+use std::path::PathBuf;
+
+// 2. External crates
+use anyhow::{Context, Result};
+
+// 3. Crate-internal
+use crate::types::AgentProvider;
+```
+
+### Error handling
+
+The project uses `anyhow` exclusively. No custom error types. Prefer `.context()` / `.with_context()` over `.unwrap()`. Error messages should be lowercase with no trailing punctuation.
+
+```rust
+let content = std::fs::read_to_string(path)
+    .context("failed to read manifest")?;
+```
+
+### Naming
+
+- Functions: `snake_case` (`scan_agent_files`, `cmd_install`)
+- Types/Enums: `PascalCase` (`FileMapping`, `AgentProvider`)
+- Constants: `UPPER_SNAKE_CASE` (`KIND_DIRS`)
+- Modules: `snake_case`, flat structure (all in `src/`)
+
+### Platform-specific code
+
+Gate with `#[cfg(unix)]` / `#[cfg(windows)]`. See `installer.rs` for examples.
+
+## Testing
+
+### Where tests live
+
+Tests are inline `#[cfg(test)] mod tests` blocks within each module. There is no separate `tests/` directory and no fixture files.
+
+### Running tests
+
+```sh
+# All tests
+cargo test
+
+# Single test by name substring
+cargo test save_and_roundtrip
+
+# Nested module path
+cargo test tests::load_manifest::from_dir
+
+# Exact match
+cargo test -p agentfiles save_and_roundtrip -- --exact
+```
+
+### Test patterns
+
+- Most tests return `Result<()>` and use `?` for propagation.
+- Use `tempfile::TempDir` for filesystem tests. Create test data inline.
+- Symlink-specific tests are gated with `#[cfg(unix)]`.
+- Descriptive `snake_case` names without a `test_` prefix.
+
+## Pull Requests
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes, following the code style above.
+3. Ensure `just ci` (or the equivalent manual commands) passes locally.
+4. Open a pull request against `main`.
+
+CI will automatically run formatting checks, clippy lints, and tests across Linux, macOS, and Windows. All checks must pass before merging.
+
+Keep commits focused and write clear commit messages that explain the _why_ behind the change.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,275 @@
-# agent-files
-A CLI that unifies installation of agent files in mulitple agentic coding providers
+# agentfiles
+
+> **Warning:** This project is in early development (v0.0.1) and is **not production-ready**.
+> APIs, CLI flags, manifest format, and behavior may change without notice between versions.
+> Use at your own risk.
+
+A CLI that installs agent files (skills, commands, agents) across multiple agentic coding providers from a unified `agentfiles.json` manifest.
+
+Write your agent files once, install them everywhere -- Claude Code, OpenCode, Codex, and Cursor.
+
+## Supported Providers
+
+| Provider | Skills | Commands | Agents |
+|---|---|---|---|
+| Claude Code | Yes | Yes | Yes |
+| OpenCode | Yes | Yes | Yes |
+| Codex | Yes | - | - |
+| Cursor | Yes | Yes | Yes |
+
+Run `agentfiles matrix` to see this table at any time.
+
+## Installation
+
+### Shell script (Linux / macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/leodiegues/agentfiles/main/install.sh | sh
+```
+
+You can pin a version with `VERSION=v0.0.1` and change the install location with `INSTALL_DIR`:
+
+```sh
+VERSION=v0.0.1 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/leodiegues/agentfiles/main/install.sh | sh
+```
+
+### Cargo
+
+```sh
+cargo install agentfiles
+```
+
+### Build from source
+
+```sh
+git clone https://github.com/leodiegues/agentfiles.git
+cd agentfiles
+cargo build --release
+# Binary is at target/release/agentfiles
+```
+
+## Quick Start
+
+```sh
+# 1. Create a directory with some agent files
+mkdir -p my-agents/skills/code-review
+cat > my-agents/skills/code-review/SKILL.md << 'EOF'
+# Code Review
+Review code changes for bugs, style issues, and improvements.
+EOF
+
+mkdir -p my-agents/commands
+cat > my-agents/commands/deploy.md << 'EOF'
+# Deploy
+Run the deployment pipeline for the current project.
+EOF
+
+# 2. Initialize a manifest
+cd my-agents
+agentfiles init
+
+# 3. Install into the current project for all providers
+agentfiles install
+```
+
+This creates an `agentfiles.json` manifest from the discovered files and installs them into each provider's expected directory structure.
+
+## Commands
+
+### `agentfiles init`
+
+Initialize a new `agentfiles.json` manifest by auto-discovering agent files in the target directory.
+
+```
+agentfiles init [PATH] [OPTIONS]
+```
+
+| Option | Description | Default |
+|---|---|---|
+| `PATH` | Directory to initialize | `.` (current directory) |
+| `-n, --name <NAME>` | Package name | Inferred from directory name |
+
+The command scans for `skills/`, `commands/`, and `agents/` directories and generates a manifest with all discovered files.
+
+```sh
+# Initialize in the current directory
+agentfiles init
+
+# Initialize in a specific directory with a custom name
+agentfiles init ./my-agents --name "my-custom-agents"
+```
+
+### `agentfiles install`
+
+Install agent files from a manifest or remote git repository into provider directories.
+
+```
+agentfiles install [SOURCE] [OPTIONS]
+```
+
+| Option | Description | Default |
+|---|---|---|
+| `SOURCE` | Local path, directory, or git URL | `.` (current directory) |
+| `-s, --scope <SCOPE>` | Installation scope: `project` or `global` | `project` |
+| `-p, --providers <PROVIDERS>` | Target providers (comma-separated) | All providers |
+| `--strategy <STRATEGY>` | File placement: `copy` or `link` (symlink) | Per-file manifest setting |
+| `--root <ROOT>` | Project root directory | `.` |
+
+**Install from local directory:**
+
+```sh
+# Install all files from the current directory to all providers
+agentfiles install
+
+# Install to specific providers only
+agentfiles install -p claude-code,cursor
+
+# Install globally (user-wide, not project-scoped)
+agentfiles install -s global
+
+# Use symlinks instead of copies
+agentfiles install --strategy link
+
+# Install from a specific directory into a specific project root
+agentfiles install ./my-agents --root ./my-project
+```
+
+**Install from a remote git repository:**
+
+```sh
+# Install from a GitHub repository
+agentfiles install github.com/org/repo
+
+# Install from a specific branch or tag
+agentfiles install github.com/org/repo@v1.0
+
+# Install from a full URL
+agentfiles install https://github.com/org/repo.git@main
+```
+
+Provider names for `-p` are: `claude-code`, `opencode`, `codex`, `cursor`.
+
+### `agentfiles scan`
+
+Scan a local directory or remote git repository for agent files without installing them. Useful for previewing what would be discovered.
+
+```
+agentfiles scan [SOURCE]
+```
+
+| Option | Description | Default |
+|---|---|---|
+| `SOURCE` | Local path or git URL | `.` (current directory) |
+
+```sh
+# Scan the current directory
+agentfiles scan
+
+# Scan a remote repository
+agentfiles scan github.com/org/repo@main
+```
+
+### `agentfiles matrix`
+
+Display the provider compatibility matrix showing which file kinds each provider supports.
+
+```sh
+agentfiles matrix
+```
+
+## Manifest Format
+
+The `agentfiles.json` manifest describes a collection of agent files:
+
+```json
+{
+  "name": "my-agents",
+  "version": "0.1.0",
+  "description": "A collection of useful agent skills and commands",
+  "author": "Your Name",
+  "repository": "https://github.com/org/repo",
+  "files": [
+    {
+      "path": "skills/code-review/SKILL.md",
+      "kind": "Skill"
+    },
+    {
+      "path": "commands/deploy.md",
+      "kind": "Command"
+    },
+    {
+      "path": "agents/security.md",
+      "kind": "Agent",
+      "strategy": "link"
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Package name |
+| `version` | Yes | Package version |
+| `description` | No | Short description |
+| `author` | No | Author name |
+| `repository` | No | Source repository URL |
+| `files` | Yes | Array of file mappings |
+
+### File mapping fields
+
+| Field | Required | Description |
+|---|---|---|
+| `path` | Yes | Relative path to the file from the manifest directory |
+| `kind` | Yes | File type: `Skill`, `Command`, or `Agent` |
+| `strategy` | No | Placement strategy: `copy` (default) or `link` (symlink) |
+
+## Remote Git Sources
+
+agentfiles can install directly from git repositories. Supported URL formats:
+
+| Format | Example |
+|---|---|
+| Shorthand | `github.com/org/repo` |
+| Shorthand + ref | `github.com/org/repo@v1.0` |
+| HTTPS | `https://github.com/org/repo.git` |
+| SSH | `git@github.com:org/repo.git` |
+
+Recognized shorthand hosts: `github.com`, `gitlab.com`, `bitbucket.org`, `codeberg.org`, `sr.ht`.
+
+Remote repositories are cached locally. Subsequent installs from the same URL will fetch updates instead of re-cloning.
+
+The remote repository should either contain an `agentfiles.json` manifest or use the standard directory structure so that files can be auto-discovered.
+
+## File Conventions
+
+agentfiles expects agent files to follow a specific directory structure:
+
+```
+skills/
+  code-review/
+    SKILL.md          # Each skill is a directory with a SKILL.md file
+  refactor/
+    SKILL.md
+commands/
+  deploy.md           # Each command is a .md file
+  test.md
+agents/
+  security.md         # Each agent is a .md file
+  performance.md
+```
+
+- **Skills** -- A directory containing a `SKILL.md` file (e.g., `skills/code-review/SKILL.md`).
+- **Commands** -- A `.md` file in the `commands/` directory (e.g., `commands/deploy.md`).
+- **Agents** -- A `.md` file in the `agents/` directory (e.g., `agents/security.md`).
+
+This structure is used by both `agentfiles init` (for auto-discovery) and `agentfiles scan`.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, testing conventions, and how to submit changes.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
This pull request introduces significant improvements to project documentation, focusing on onboarding, usage, and contribution guidelines. The most notable changes are the addition of a comprehensive `CONTRIBUTING.md` file and a major rewrite of the `README.md` to provide clearer instructions, usage examples, and detailed reference material for users and contributors.

**Documentation improvements:**

* Added a new `CONTRIBUTING.md` file with detailed instructions on development setup, code style, testing, and pull request workflow to help new contributors get started and follow project standards.
* Completely rewrote the `README.md` to include:
  - A warning about early development status and API instability.
  - Expanded installation instructions (shell script, Cargo, building from source).
  - A quick start guide with step-by-step examples.
  - Detailed documentation for all CLI commands, their options, and usage examples.
  - Manifest file format reference, including required fields and file mapping conventions.
  - Explanation of supported remote git sources and file structure conventions.
  - Reference to the new `CONTRIBUTING.md` for further contribution details.