### PR TITLE
feat: add debug logging and verbose CLI flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ categories = ["command-line-utilities", "development-tools"]
 anyhow = "1.0.101"
 clap = { version = "4.5.57", features = ["derive"] }
 dirs = "6"
+env_logger = "0.11.9"
+log = "0.4.29"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,9 @@ use crate::types::{AgentProvider, FileScope, FileStrategy};
     version
 )]
 pub struct Cli {
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,12 @@ use clap::Parser;
 fn main() -> Result<()> {
     let args = cli::Cli::parse();
 
+    if args.verbose {
+        unsafe { std::env::set_var("RUST_LOG", "debug") };
+    }
+
+    env_logger::init();
+
     match args.command {
         cli::Command::Install {
             source,


### PR DESCRIPTION
This pull request introduces verbose logging throughout the codebase to aid debugging and traceability of operations. It adds support for a `--verbose` CLI flag, integrates the `log` and `env_logger` crates, and inserts `debug!` log statements in key functions across the `commands`, `git`, and `installer` modules. The changes also remove sectioned comments to streamline the code.

Logging and debug support:

* Added `log` and `env_logger` dependencies in `Cargo.toml` to enable logging throughout the project.
* Introduced `debug!` log statements in critical functions in `src/commands.rs`, `src/git.rs`, and `src/installer.rs` to trace command execution, source resolution, file operations, and git interactions. [[1]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520R4-L12) [[2]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R6) [[3]](diffhunk://#diff-4904922dab3fd7bd66e213f49476ad3aa39a8a7c0cb24f68a68343909bbdaab4R5)

CLI improvements:

* Added a `--verbose` global flag to the CLI, allowing users to enable verbose logging for debugging purposes.

Codebase cleanup:

* Removed sectioned comments in `src/commands.rs` to streamline the code and improve readability. [[1]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L318-L321) [[2]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L615-L618) [[3]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L648-L651) [[4]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L676-L679) [[5]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L717-L720)

Logging enhancements in git operations:

* Added `debug!` statements to log git clone, fetch, checkout, and reset operations, including cache hits/misses and default branch detection. [[1]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R115-R138) [[2]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R240) [[3]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R263) [[4]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R300) [[5]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R332) [[6]](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R346)

These changes collectively improve observability and make troubleshooting much easier during development and usage.